### PR TITLE
Implement intro and auth screens

### DIFF
--- a/learn-tigrinya/App.tsx
+++ b/learn-tigrinya/App.tsx
@@ -1,11 +1,20 @@
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import IntroScreen from './IntroScreen';
+import AuthScreen from './AuthScreen';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
+  const [showIntro, setShowIntro] = useState(true);
+
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
       <StatusBar style="auto" />
+      {showIntro ? (
+        <IntroScreen onFinish={() => setShowIntro(false)} />
+      ) : (
+        <AuthScreen />
+      )}
     </View>
   );
 }
@@ -14,7 +23,5 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 });

--- a/learn-tigrinya/AuthScreen.tsx
+++ b/learn-tigrinya/AuthScreen.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+
+export default function AuthScreen() {
+  const [isRegister, setIsRegister] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{isRegister ? 'Register' : 'Login'}</Text>
+      <TextInput placeholder="Email" style={styles.input} autoCapitalize="none" />
+      <TextInput placeholder="Password" secureTextEntry style={styles.input} />
+      {isRegister && (
+        <TextInput placeholder="Confirm Password" secureTextEntry style={styles.input} />
+      )}
+      <TouchableOpacity style={styles.button}>
+        <Text style={styles.buttonText}>{isRegister ? 'Register' : 'Login'}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => setIsRegister(!isRegister)}>
+        <Text style={styles.link}>
+          {isRegister ? 'Have an account? Login' : 'No account? Register'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 5,
+  },
+  button: {
+    backgroundColor: '#007aff',
+    padding: 15,
+    borderRadius: 5,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  link: {
+    marginTop: 15,
+    textAlign: 'center',
+    color: '#007aff',
+  },
+});

--- a/learn-tigrinya/IntroScreen.tsx
+++ b/learn-tigrinya/IntroScreen.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
+
+interface IntroScreenProps {
+  onFinish: () => void;
+}
+
+export default function IntroScreen({ onFinish }: IntroScreenProps) {
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.sequence([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 1000,
+        useNativeDriver: true,
+      }),
+      Animated.delay(2000),
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: 500,
+        useNativeDriver: true,
+      }),
+    ]).start(onFinish);
+  }, [onFinish, opacity]);
+
+  return (
+    <View style={styles.container}>
+      <Animated.Text style={[styles.title, { opacity }]}>እንቋዕ ብደሓን መጻእኩም!</Animated.Text>
+      <Animated.Text style={[styles.subtitle, { opacity }]}>Discover the beauty of the Tigrinya language</Animated.Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+    padding: 20,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    marginTop: 20,
+    textAlign: 'center',
+  },
+});

--- a/learn-tigrinya/index.js
+++ b/learn-tigrinya/index.js
@@ -1,1 +1,4 @@
-import 'expo-router/entry';
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);


### PR DESCRIPTION
## Summary
- add intro screen with simple animation showing Tigrinya greeting
- add login/register screen with basic form
- link the two screens in the main `App`
- adjust the entry file

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685adad18880832bb7651160b892377f