### PR TITLE
Add Tigrinya alphabet intro background and info screen

### DIFF
--- a/learn-tigrinya/App.tsx
+++ b/learn-tigrinya/App.tsx
@@ -1,17 +1,24 @@
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import IntroScreen from './IntroScreen';
+import InfoScreen from './InfoScreen';
 import AuthScreen from './AuthScreen';
 import { StatusBar } from 'expo-status-bar';
 
 export default function App() {
   const [showIntro, setShowIntro] = useState(true);
+  const [showInfo, setShowInfo] = useState(false);
 
   return (
     <View style={styles.container}>
       <StatusBar style="auto" />
       {showIntro ? (
-        <IntroScreen onFinish={() => setShowIntro(false)} />
+        <IntroScreen onFinish={() => {
+          setShowIntro(false);
+          setShowInfo(true);
+        }} />
+      ) : showInfo ? (
+        <InfoScreen onContinue={() => setShowInfo(false)} />
       ) : (
         <AuthScreen />
       )}

--- a/learn-tigrinya/InfoScreen.tsx
+++ b/learn-tigrinya/InfoScreen.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+
+interface InfoScreenProps {
+  onContinue: () => void;
+}
+
+export default function InfoScreen({ onContinue }: InfoScreenProps) {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.heading}>About Tigrinya & Ge'ez</Text>
+      <Text style={styles.paragraph}>
+        Tigrinya is a Semitic language spoken by millions in Eritrea and northern Ethiopia. It is written using the ancient Ge'ez script, an abugida where each symbol represents a consonant-vowel combination.
+      </Text>
+      <Text style={styles.paragraph}>
+        The Ge'ez script dates back nearly two thousand years and remains in liturgical use by the Ethiopian and Eritrean Orthodox churches. Tigrinya evolved from Ge'ez and retains many of its grammatical features.
+      </Text>
+      <Text style={styles.paragraph}>
+        Today, Tigrinya is known for its rich verb morphology and variety of dialects across the region. Learning the Ge'ez alphabet is the first step toward appreciating this beautiful language.
+      </Text>
+      <TouchableOpacity style={styles.button} onPress={onContinue}>
+        <Text style={styles.buttonText}>Continue</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  paragraph: {
+    fontSize: 16,
+    marginBottom: 15,
+  },
+  button: {
+    marginTop: 20,
+    padding: 15,
+    backgroundColor: '#007aff',
+    borderRadius: 5,
+    alignSelf: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/learn-tigrinya/IntroScreen.tsx
+++ b/learn-tigrinya/IntroScreen.tsx
@@ -1,6 +1,42 @@
 import React, { useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, Animated } from 'react-native';
 
+const ALPHABET_LINES = [
+  'ሀሁሂሃሄህሆ',
+  'ለሉሊላሌልሎ',
+  'ሐሑሒሓሔሕሖ',
+  'መሙሚማሜምሞ',
+  'ሠሡሢሣሤሥሦ',
+  'ረሩሪራሬርሮ',
+  'ሰሱሲሳሴስሶ',
+  'ሸሹሺሻሼሽሾ',
+  'ቀቁቂቃቄቅቆ',
+  'በቡቢባቤብቦ',
+  'ተቱቲታቴትቶ',
+  'ቸቹቺቻቼችቾ',
+  'ኀኁኂኃኄኅኆ',
+  'ነኑኒናኔንኖ',
+  'ኘኙኚኛኜኝኞ',
+  'አኡኢኣኤእኦ',
+  'ከኩኪካኬክኮ',
+  'ኸኹኺኻኼኽኾ',
+  'ወዉዊዋዌውዎ',
+  'ዐዑዒዓዔዕዖ',
+  'ዘዙዚዛዜዝዞ',
+  'ዠዡዢዣዤዥዦ',
+  'የዩዪያዬይዮ',
+  'ደዱዲዳዴድዶ',
+  'ጀጁጂጃጄጅጆ',
+  'ገጉጊጋጌግጎ',
+  'ጠጡጢጣጤጥጦ',
+  'ጨጩጪጫጬጭጮ',
+  'ጰጱጲጳጴጵጶ',
+  'ጸጹጺጻጼጽጾ',
+  'ፀፁፂፃፄፅፆ',
+  'ፈፉፊፋፌፍፎ',
+  'ፐፑፒፓፔፕፖ',
+];
+
 interface IntroScreenProps {
   onFinish: () => void;
 }
@@ -26,6 +62,19 @@ export default function IntroScreen({ onFinish }: IntroScreenProps) {
 
   return (
     <View style={styles.container}>
+      <View style={styles.alphabetWrapper} pointerEvents="none">
+        {ALPHABET_LINES.map((line, idx) => (
+          <Text
+            key={idx}
+            style={[
+              styles.alphabetText,
+              { opacity: 0.5 - (idx / (ALPHABET_LINES.length - 1)) * 0.4 },
+            ]}
+          >
+            {line}
+          </Text>
+        ))}
+      </View>
       <Animated.Text style={[styles.title, { opacity }]}>እንቋዕ ብደሓን መጻእኩም!</Animated.Text>
       <Animated.Text style={[styles.subtitle, { opacity }]}>Discover the beauty of the Tigrinya language</Animated.Text>
     </View>
@@ -39,6 +88,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: '#fff',
     padding: 20,
+  },
+  alphabetWrapper: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  alphabetText: {
+    fontSize: 16,
+    color: '#000',
   },
   title: {
     fontSize: 28,


### PR DESCRIPTION
## Summary
- add alphabet background to IntroScreen
- show InfoScreen with details on Tigrinya and Ge'ez
- update App.tsx to route through Intro->Info->Auth

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aded9b90c832b9a5b469112697d7f